### PR TITLE
Fix wrap function to handle before and other functions without first argument as string parameter

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,23 @@ export type MochaBody = (this: IHookCallbackContext) => void;
 
 function wrapWithRun(body: MochaBody){
     return function (this: IHookCallbackContext, done: MochaDone) {
-        run(() => {
-            return body.apply(this);
-        }).then(done, done);
+        function doneErr(err: any) {
+            if (err && err instanceof Error) {
+                done(err);
+            } else {
+                done();
+            }
+        }
+        // check done is called only when declared (normal mocha behaviour)
+        if (body.length === 0) {
+            run(() => {
+                return body.call(this);
+            }).then(doneErr, done);
+        } else {
+            run(() => {
+                return body.call(this, doneErr);
+            });
+        }
     };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,13 @@ import { run } from 'f-promise';
 function wrapWithRun(fn: Function) {
     return function (name: string, body: () => void) {
         if (!body) {
-            return fn(name);
+            if (typeof name === 'string') {
+                return fn(name);
+            } else if (typeof name === 'function') {
+                return fn(function (done: MochaDone) {
+                    run(() => name()).then(done, done);
+                });
+            }
         }
         return fn(name, function (done: MochaDone) {
             run(() => body()).then(done, done);
@@ -27,4 +33,6 @@ export function setup() {
     patchFn('it', [ 'only', 'skip']);
     patchFn('before');
     patchFn('beforeEach');
+    patchFn('after');
+    patchFn('afterEach');
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,37 @@
 import { run } from 'f-promise';
+import { IHookCallbackContext } from 'mocha';
 
+export type MochaBody = (this: IHookCallbackContext) => void;
 
-function wrapWithRun(fn: Function) {
-    return function (name: string, body: () => void) {
+function wrapWithRun(body: MochaBody){
+    return function (this: IHookCallbackContext, done: MochaDone) {
+        run(() => {
+            return body.apply(this);
+        }).then(done, done);
+    };
+}
+
+function overrideFn(fn: Function) {
+    return function (name: string | MochaBody, body?: MochaBody) {
         if (!body) {
             if (typeof name === 'string') {
                 return fn(name);
             } else if (typeof name === 'function') {
-                return fn(function (done: MochaDone) {
-                    run(() => name()).then(done, done);
-                });
+                return fn(wrapWithRun(name));
             }
         }
-        return fn(name, function (done: MochaDone) {
-            run(() => body()).then(done, done);
-        });
+        return fn(name, wrapWithRun(body));
     }
 }
+
 export function setup() {
     function patchFn(fnName: string, subNames?: string[]) {
         subNames = subNames || [];
         const _fn = glob[fnName];
         if (_fn.wrapped) return;
-        glob[fnName] = wrapWithRun(_fn);
+        glob[fnName] = overrideFn(_fn);
         subNames.forEach((subFnName) => {
-            glob[fnName][subFnName] = wrapWithRun(_fn[subFnName]);
+            glob[fnName][subFnName] = overrideFn(_fn[subFnName]);
         });
         glob[fnName].wrapped = true;
     }

--- a/test/basic-test.ts
+++ b/test/basic-test.ts
@@ -88,4 +88,23 @@ describe("basic test on beforeEach", () => {
             assert(expected, 'got expected value set in before');
         });
     });
+
+    describe("async test without string prefix", () => {
+        let expected: boolean;
+        beforeEach(() => {
+            assert(true, 'got false before wait');
+            wait(cb => setTimeout(cb, 0));
+            assert(true, 'got true after wait');
+            expected = true;
+        });
+
+        it('check expected value set in beforeEach', () => {
+            assert(expected, 'got expected value set in before');
+            expected = false;
+        });
+
+        it('check expected value set in beforeEach but changed in previous it', () => {
+            assert(expected, 'got expected value set in before');
+        });
+    });
 });

--- a/test/basic-test.ts
+++ b/test/basic-test.ts
@@ -91,7 +91,8 @@ describe("basic test on beforeEach", () => {
 
     describe("async test without string prefix", () => {
         let expected: boolean;
-        beforeEach(() => {
+        beforeEach(function () {
+            this.timeout(20000);
             assert(true, 'got false before wait');
             wait(cb => setTimeout(cb, 0));
             assert(true, 'got true after wait');

--- a/test/basic-test.ts
+++ b/test/basic-test.ts
@@ -108,4 +108,35 @@ describe("basic test on beforeEach", () => {
             assert(expected, 'got expected value set in before');
         });
     });
+
+    describe("async test with done parameter called too soon", () => {
+        let expected: boolean;
+        beforeEach(function (done) {
+            done();
+            wait(() => setTimeout(() => {
+                expected = true;
+            }, 1000));
+        });
+
+        it('check expected value set in beforeEach', (done) => {
+            assert(!expected, 'got expected value set in before');
+            done();
+        });
+    });
+
+    describe("async test with done parameter called in time", () => {
+        let expected: boolean;
+        beforeEach(function (done) {
+            assert(true, 'got true after wait');
+
+            setTimeout(() => {
+                expected = true;
+                done();
+            }, 1000);
+        });
+
+        it('check expected value set in beforeEach', () => {
+            assert(expected, 'got expected value set in before');
+        });
+    });
 });


### PR DESCRIPTION
@bjouhier My previous pull request introduced a bug when calling before function (for instance) without string first parameter.

I also considered after and afterEach functions.